### PR TITLE
New consumer not receiving existing messages immediately

### DIFF
--- a/RabbitMQ.Client.Mock.Tests/ConsumerTests.cs
+++ b/RabbitMQ.Client.Mock.Tests/ConsumerTests.cs
@@ -6,6 +6,62 @@ namespace RabbitMQ.Client.Mock.Tests;
 public class ConsumerTests : TestBase
 {
     [Fact]
+    public async Task When_Creating_And_Using_Consumer_For_Messages_From_Existing_Queue_Containing_Messages_Then_MessageDelivery_ShouldStart_Immediately()
+    {
+        // Arrange
+        var testData = await CreateTestMessagesAsync(50);
+        var queueName = await CreateUniqueQueueNameAsync();
+        var connection = await factory.CreateConnectionAsync();
+        var publisher = await connection.CreateChannelAsync();
+        var consumer = await connection.CreateChannelAsync();
+        await publisher.QueueDeclareAsync(queueName);
+        var consumerSink = new AsyncEventingBasicConsumer(consumer);
+        var properties = new BasicProperties
+        {
+            ContentType = "text/plain",
+            DeliveryMode = DeliveryModes.Persistent, // persistent
+            Priority = 0,
+            Headers = new Dictionary<string, object?> { { "x-match", "all" } }
+        };
+        var messagesPublished = 0;
+        var messagesReceived = 0;
+        var consumerCount = 0u;
+
+        // Act
+        foreach (var message in testData)
+        {
+            var body = System.Text.Encoding.UTF8.GetBytes(message);
+            await publisher.BasicPublishAsync(string.Empty, queueName, false, properties, body);
+            messagesPublished++;
+        }
+        consumerSink.ReceivedAsync += async (sender, args) =>
+        {
+            await Task.Delay(1);
+            var body = args.Body.ToArray();
+            var message = System.Text.Encoding.UTF8.GetString(body);
+            Console.WriteLine($"Received message: {message}");
+            messagesReceived++;
+        };
+        var consumerTag = await consumer.BasicConsumeAsync(queueName, true, consumerSink);
+
+        await WaitUntilAsync(() => messagesReceived == messagesPublished, 10000, 100);
+        consumerCount = await consumer.ConsumerCountAsync(queueName, cancellationToken: default);
+
+        // Assert
+        Assert.True(consumerCount == 1);
+        Assert.Equal(messagesPublished, messagesReceived);
+
+        // Clean-up
+        await consumer.BasicCancelAsync(consumerTag);
+        await publisher.QueueDeleteAsync(queueName);
+        await publisher.CloseAsync();
+        await consumer.CloseAsync();
+        await consumer.DisposeAsync();
+        await connection.CloseAsync();
+        await connection.DisposeAsync();
+    }
+
+    [Fact]
     public async Task When_Creating_And_Using_Consumer_For_Messages_From_Queue_Then_ConsumerCount_ShouldBe_One()
     {
         // Arrange

--- a/RabbitMQ.Client.Mock/RabbitMQ.Client.Mock.csproj
+++ b/RabbitMQ.Client.Mock/RabbitMQ.Client.Mock.csproj
@@ -16,7 +16,7 @@
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/ReleaseNotes.txt"))</PackageReleaseNotes>
     <PackageLicenceExpression>GPL-3.0-or-later</PackageLicenceExpression>
     <PackageLicenseFile>licence.txt</PackageLicenseFile>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RabbitMQ.Client.Mock/Releasenotes.txt
+++ b/RabbitMQ.Client.Mock/Releasenotes.txt
@@ -1,3 +1,6 @@
+1.2.4	Release (2025-05-23)
+- Fixed a bug that a new consumer on an existing queue containing messages would only receive messages after 30 seconds.
+
 1.2.3	Release (2025-05-22)
 - Removed obsolete code (PublishMessageOperation)
 - Fixed issue with AsyncAutoResetEvent sometimes immediately reporting timeout.

--- a/RabbitMQ.Client.Mock/Server/Operations/BasicConsumeOperation.cs
+++ b/RabbitMQ.Client.Mock/Server/Operations/BasicConsumeOperation.cs
@@ -43,7 +43,7 @@ internal class BasicConsumeOperation(IRabbitServer server, IChannel channel, str
                 consumerTag = await Server.GenerateUniqueConsumerTag(queue).ConfigureAwait(false);
             }
 
-            // now, add the new consumer binding.
+            // now, add the new consumer binding, and notify the queue of its existence.
             var binding = new ConsumerBinding(queueInstance, consumer)
             {
                 ChannelNumber = channel.ChannelNumber,
@@ -54,6 +54,8 @@ internal class BasicConsumeOperation(IRabbitServer server, IChannel channel, str
             };
 
             Server.ConsumerBindings.TryAdd(consumerTag, binding);
+            await queueInstance.NotifyConsumerAdded();
+
             return OperationResult.Success($"Consumer '{consumerTag}' added to queue '{queue}' with autoAck={autoAck}, noLocal={noLocal}, exclusive={exclusive}.", consumerTag);
         }
         catch (Exception ex)

--- a/RabbitMQ.Client.Mock/Server/Queues/RabbitQueue.cs
+++ b/RabbitMQ.Client.Mock/Server/Queues/RabbitQueue.cs
@@ -114,6 +114,7 @@ internal class RabbitQueue : IDisposable, IAsyncDisposable
         }
         message.Queue = Name.ToString();
         _queue.AddFirst(message);
+        _waitHandle.Set();
         return ValueTask.CompletedTask;
     }
 
@@ -122,6 +123,12 @@ internal class RabbitQueue : IDisposable, IAsyncDisposable
         var count = (uint)_queue.Count;
         _queue.Clear();
         return ValueTask.FromResult(count);
+    }
+
+    public ValueTask NotifyConsumerAdded()
+    {
+        _waitHandle.Set();
+        return ValueTask.CompletedTask;
     }
 
     private async Task DeliveryLoop(CancellationToken cancellationToken)


### PR DESCRIPTION
Fixed issue where message delivery isn't started immediately when consumer added on existing queue containing messages.