### PR TITLE
Fixed issue with headers exchange matching does not mimic normal Rabb…

### DIFF
--- a/RabbitMQ.Client.Mock/RabbitMQ.Client.Mock.csproj
+++ b/RabbitMQ.Client.Mock/RabbitMQ.Client.Mock.csproj
@@ -16,7 +16,7 @@
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/ReleaseNotes.txt"))</PackageReleaseNotes>
     <PackageLicenceExpression>GPL-3.0-or-later</PackageLicenceExpression>
     <PackageLicenseFile>licence.txt</PackageLicenseFile>
-    <Version>1.2.4</Version>
+    <Version>1.2.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RabbitMQ.Client.Mock/Releasenotes.txt
+++ b/RabbitMQ.Client.Mock/Releasenotes.txt
@@ -1,3 +1,6 @@
+1.2.5	Release (2025-05-23)
+- Fixed a bug with the headers exchange not working correctly when using the "x-match" header.
+
 1.2.4	Release (2025-05-23)
 - Fixed a bug that a new consumer on an existing queue containing messages would only receive messages after 30 seconds.
 

--- a/RabbitMQ.Client.Mock/Server/Exchanges/HeadersExchange.cs
+++ b/RabbitMQ.Client.Mock/Server/Exchanges/HeadersExchange.cs
@@ -105,11 +105,14 @@ internal class HeadersExchange(IRabbitServer server, string name) : RabbitExchan
             bool doBind = false;
 
             // all criteria must match arguments.
-            if (match.Equals("all"))
+            if (match.Equals("all") || match.Equals("all-with-x"))
             {
                 // check if all criteria match.
+                var filteredHeaders = match.Equals("all")
+                    ? headers.Where(x => !x.Key.StartsWith("x-")).ToDictionary(x => x.Key, x => x.Value)
+                    : headers;
                 var matches = true;
-                foreach (var header in headers)
+                foreach (var header in filteredHeaders)
                 {
                     if (!(criteria.ContainsKey(header.Key) && criteria[header.Key] == header.Value))
                     {
@@ -120,11 +123,14 @@ internal class HeadersExchange(IRabbitServer server, string name) : RabbitExchan
                 doBind = matches;
             }
 
-            if (match.Equals("any"))
+            if (match.Equals("any") || match.Equals("any-with-x"))
             {
                 // check if any criteria match.
+                var filteredHeaders = match.Equals("any") 
+                    ? headers.Where(x => !x.Key.StartsWith("x-")).ToDictionary(x => x.Key, x => x.Value)
+                    : headers;
                 var matches = false;
-                foreach (var header in headers)
+                foreach (var header in filteredHeaders)
                 {
                     if (criteria.ContainsKey(header.Key) && criteria[header.Key] == header.Value)
                     {
@@ -186,11 +192,14 @@ internal class HeadersExchange(IRabbitServer server, string name) : RabbitExchan
             bool doBind = false;
 
             // all criteria must match arguments.
-            if (match.Equals("all"))
+            if (match.Equals("all") || match.Equals("all-with-x"))
             {
                 // check if all criteria match.
+                var filteredHeaders = match.Equals("all")
+                    ? headers.Where(x => !x.Key.StartsWith("x-")).ToDictionary(x => x.Key, x => x.Value)
+                    : headers;
                 var matches = true;
-                foreach (var header in headers)
+                foreach (var header in filteredHeaders)
                 {
                     if (!(criteria.ContainsKey(header.Key) && criteria[header.Key] == header.Value))
                     {
@@ -201,11 +210,14 @@ internal class HeadersExchange(IRabbitServer server, string name) : RabbitExchan
                 doBind = matches;
             }
 
-            if (match.Equals("any"))
+            if (match.Equals("any") || match.Equals("any-with-x"))
             {
                 // check if any criteria match.
+                var filteredHeaders = match.Equals("any")
+                    ? headers.Where(x => !x.Key.StartsWith("x-")).ToDictionary(x => x.Key, x => x.Value)
+                    : headers;
                 var matches = false;
-                foreach (var header in headers)
+                foreach (var header in filteredHeaders)
                 {
                     if (criteria.ContainsKey(header.Key) && criteria[header.Key] == header.Value)
                     {


### PR DESCRIPTION
…itMQ.Client behavior.

The regular client does not evaluate x-... headers when 'all' or 'any' was applied. It uses 'all-with-x' or 'any-with-x' for that.

The mocking library did not check for the 'x-...' filters when matching, and checked all headers, including the x-...  headers.